### PR TITLE
Roll own JWT middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1750,45 +1750,6 @@
         }
       }
     },
-    "express-jwt": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
-      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
-      "requires": {
-        "async": "^1.5.0",
-        "express-unless": "^0.3.0",
-        "jsonwebtoken": "^8.1.0",
-        "lodash.set": "^4.0.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
-          "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
-          "requires": {
-            "jws": "^3.1.5",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
-    "express-unless": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
-      "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3579,11 +3540,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
       "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.some": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "cheerio": "^0.22.0",
     "cors": "^2.8.0",
     "express": "^4.14.0",
-    "express-jwt": "^5.1.0",
     "forecast.io": "0.0.11",
     "fs-extra": "^7.0.1",
     "googleapis": "^43.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,6 @@ MongoClient.connect(config.mongodb.uri).then(async (client: MongoClient) => {
 
 	// Enable JWT authentication middleware
 	app.use(jwt.authorize(db));
-	app.use(jwt.fallback);
-	app.use(jwt.catchUnauthorized);
 
 	// Enable admin overrides
 	app.use(api.adminOverride);

--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -1,127 +1,140 @@
 import { Action } from '@mymicds/sdk';
-import { NextFunction, Request, Response } from 'express';
-import expressJWT, { IsRevokedCallback } from 'express-jwt';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
 import * as jwt from 'jsonwebtoken';
-import { SignOptions } from 'jsonwebtoken';
 import { Db, ObjectID } from 'mongodb';
 import * as _ from 'underscore';
-import { promisify } from 'util';
 import * as api from './api';
 import config from './config';
 import * as users from './users';
-import { UserDoc } from './users';
+import { StringDict } from './utils';
+
+declare global {
+	namespace Express {
+		interface Request {
+			user: false | {
+				user: string;
+				scopes: { [scope: string]: true };
+			};
+		}
+	}
+}
 
 /**
  * Verifies a JWT and assigns it to `req.user`.
  * @param db Database connection.
  * @returns An Express middleware function.
  */
-export function authorize(db: Db) {
-	return expressJWT({
-		credentialsRequired: false, // We have our own way of handling if user is authorized or not
-		secret   : config.jwt.secret,
-		isRevoked: isRevoked(db),
-		audience : config.hostedOn,
-		issuer   : config.hostedOn
-	});
+export function authorize(db: Db): RequestHandler {
+	return (req, res, next) => {
+		req.user = false;
+
+		const header = req.headers.authorization;
+
+		// If there's no auth header or it's just empty, it's probably fine and we can just ignore it
+		if (typeof header !== 'string' || header.length === 0) {
+			return;
+		}
+
+		// Otherwise, make sure it's in the correct format
+		if (!header.startsWith('Bearer ')) {
+			api.error(res, 'Authorization header must be in bearer token format.', Action.UNAUTHORIZED);
+			return;
+		}
+
+		// Verification
+
+		let payload: string | StringDict;
+
+		try {
+			payload = jwt.verify(header.substring(7), config.jwt.secret);
+		} catch (err) {
+			if (err instanceof jwt.TokenExpiredError) {
+				api.error(res, err, Action.LOGIN_EXPIRED);
+			}
+			api.error(res, err, Action.UNAUTHORIZED);
+			return;
+		}
+
+		// Express doesn't like async/await so we need promise chains
+		isRevoked(db, req, payload).then(revoked => {
+			if (revoked) {
+				api.error(res, 'Invalid token.', Action.UNAUTHORIZED);
+			} else {
+				// Type predicates can't be used asynchronously so we need to manually assert
+				const { user, scopes } = payload as StringDict;
+				req.user = { user, scopes };
+			}
+		}).catch(err => {
+			api.error(res, err, Action.UNAUTHORIZED);
+		}).finally(() => next());
+	};
 }
 
 /**
  * Checks whether a JWT is revoked or not.
  * @param db Database connection.
- * @returns A callback for the `express-jwt` package.
- */
-function isRevoked(db: Db): IsRevokedCallback {
-	return async (req, payload, done) => {
-
-		const ignoredRoutes = [
-			'/auth/logout'
-		];
-
-		// Get rid of possible ending slash
-		const testUrl = req.url.endsWith('/') ? req.url.slice(0, -1) : req.url;
-		if (ignoredRoutes.includes(testUrl)) {
-			done(null, false);
-			return;
-		}
-
-		if (typeof payload !== 'object') {
-			done(null, true);
-			return;
-		}
-
-		// Expiration date
-		const expiration = payload.exp * 1000;
-		// Make sure token hasn't expired yet
-		const timeLeft = expiration - Date.now();
-		// Make sure expiration is accurate within 30 seconds to account for time differences between computers.
-		const clockTolerance = 30;
-
-		if (timeLeft < (clockTolerance * -1000)) {
-			done(null, true);
-			return;
-		}
-
-		let isUser: boolean;
-		let userDoc: UserDoc | null;
-		try {
-			// I guess this requires parentheses?
-			({ isUser, userDoc } = await users.get(db, payload.user));
-		} catch (e) {
-			done(e, true);
-			return;
-		}
-
-		if (!isUser) {
-			done(null, true);
-			return;
-		}
-
-		// Make sure token wasn't issued before last password change
-		/*
-		 * @TODO Automatically log user out in front-end on password change
-		 * or prevent session that changed password from expiring.
-		 */
-		/* if (typeof userDoc['lastPasswordChange'] === 'object'
-				&& (payload.iat * 1000) < userDoc['lastPasswordChange'].getTime()) {
-			done(null, true);
-			return;
-		}*/
-
-		// Make sure token isn't blacklisted (usually if logged out)
-		const authJwt = req.get('Authorization')!.slice(7);
-
-		let blacklisted;
-		try {
-			blacklisted = await isBlacklisted(db, authJwt);
-		} catch (e) {
-			done(e, true);
-			return;
-		}
-
-		// Update 'lastVisited' field in user document
-		const userdata = db.collection('users');
-		await userdata.updateOne(userDoc!, { $currentDate: { lastVisited: true }});
-
-		const jwtData = db.collection('jwtWhitelist');
-		await jwtData.updateOne({ user: userDoc!._id, jwt: authJwt }, { $currentDate: { lastUsed: true }});
-
-		done(null, blacklisted);
-	};
-}
-
-/**
- * Defaults `req.user` to false if there is no user. Must be attached after the authorization middleware.
  * @param req Express request object.
- * @param res Express response object.
- * @param next Calls the next handler in the middleware chain.
+ * @param payload The JWT payload.
+ * @returns Whether the JWT is revoked.
  */
-export function fallback(req: Request, res: Response, next: NextFunction) {
-	// If user doesn't exist or is invalid, default req.user to false
-	if (typeof req.user === 'undefined') {
-		req.user = false;
+async function isRevoked(db: Db, req: Request, payload: string | StringDict) {
+	const ignoredRoutes = [
+		'/auth/logout'
+	];
+
+	// Get rid of possible ending slash
+	const testUrl = req.url.endsWith('/') ? req.url.slice(0, -1) : req.url;
+	if (ignoredRoutes.includes(testUrl)) {
+		return false;
 	}
-	next();
+
+	if (typeof payload !== 'object') {
+		return true;
+	}
+
+	// Expiration logic is handled by jwt.verify itself
+
+	// // Expiration date
+	// const expiration = payload.exp * 1000;
+	// // Make sure token hasn't expired yet
+	// const timeLeft = expiration - Date.now();
+	// // Make sure expiration is accurate within 30 seconds to account for time differences between computers.
+	// const clockTolerance = 30;
+	//
+	// if (timeLeft < (clockTolerance * -1000)) {
+	// 	return Action.LOGIN_EXPIRED;
+	// }
+
+	const { isUser, userDoc } = await users.get(db, payload.user);
+
+	if (!isUser) {
+		return true;
+	}
+
+	// Make sure token wasn't issued before last password change
+	/*
+	 * @TODO Automatically log user out in front-end on password change
+	 * or prevent session that changed password from expiring.
+	 */
+	/* if (typeof userDoc['lastPasswordChange'] === 'object'
+			&& (payload.iat * 1000) < userDoc['lastPasswordChange'].getTime()) {
+		done(null, true);
+		return;
+	}*/
+
+	// Make sure token isn't blacklisted (usually if logged out)
+	const authJwt = req.headers.authorization!.slice(7);
+
+	const blacklisted = await isBlacklisted(db, authJwt);
+
+	// Update 'lastVisited' field in user document
+	const userdata = db.collection('users');
+	await userdata.updateOne(userDoc!, { $currentDate: { lastVisited: true }});
+
+	const jwtData = db.collection('jwtWhitelist');
+	await jwtData.updateOne({ user: userDoc!._id, jwt: authJwt }, { $currentDate: { lastUsed: true }});
+
+	return blacklisted;
 }
 
 /**
@@ -148,21 +161,6 @@ export function requireScope(scope: string, message = 'You\'re not authorized in
 			api.error(res, message, Action.NOT_LOGGED_IN);
 		}
 	};
-}
-
-/**
- * Catches any authorization errors thrown by [[authorize]].
- * @param err Error from previous middleware.
- * @param req Express request object.
- * @param res Express response object.
- * @param next Calls the next handler in the middleware chain.
- */
-export function catchUnauthorized(err: Error, req: Request, res: Response, next: NextFunction) {
-	if (err.name === 'UnauthorizedError') {
-		api.error(res, err, Action.UNAUTHORIZED);
-		return;
-	}
-	next();
 }
 
 /**
@@ -199,7 +197,7 @@ export async function generate(db: Db, user: string, rememberMe: boolean, commen
 	let token;
 	try {
 		// I have to specify the type arguments cause TS is having trouble with inferring them here
-		token = await promisify<object, string, SignOptions, string>(jwt.sign)({
+		token = jwt.sign({
 			user, scopes
 		}, config.jwt.secret, {
 			subject: 'MyMICDS API',

--- a/src/libs/socket.io.ts
+++ b/src/libs/socket.io.ts
@@ -13,24 +13,25 @@ export default (io: Server) => {
 		 */
 
 		socket.on('authenticate', token => {
-			jwt.verify(token, config.jwt.secret, {
-				algorithms: ['HS256'],
-				audience: config.hostedOn,
-				issuer: config.hostedOn,
-				clockTolerance: 30
+			let decoded;
 
-			}, (err, decoded) => {
-				if (err) {
-					socket.emit('unauthorized');
-					return;
-				}
+			try {
+				decoded = jwt.verify(token, config.jwt.secret, {
+					algorithms: ['HS256'],
+					audience: config.hostedOn,
+					issuer: config.hostedOn,
+					clockTolerance: 30
+				});
+			} catch (err) {
+				socket.emit('unauthorized');
+				return;
+			}
 
-				// User is valid!
-				if (!err && decoded) {
-					(socket as any).decodedToken = decoded;
-					socket.emit('authorized');
-				}
-			});
+			// User is valid!
+			if (decoded) {
+				(socket as any).decodedToken = decoded;
+				socket.emit('authorized');
+			}
 		});
 	});
 

--- a/src/routes/authAPI.ts
+++ b/src/routes/authAPI.ts
@@ -107,7 +107,7 @@ export default ((app, db) => {
 	});
 
 	app.get('/auth/verify', (req, res) => {
-		if (!req.user.user) {
+		if (!(req.user && req.user.user)) {
 			api.error(res, 'JWT not provided!');
 			return;
 		}

--- a/src/routes/notificationsAPI.ts
+++ b/src/routes/notificationsAPI.ts
@@ -5,7 +5,7 @@ import RoutesFunction from './routesFunction';
 export default ((app, db) => {
 
 	app.post('/notifications/unsubscribe', async (req, res) => {
-		let user = req.user.user;
+		let user = req.apiUser;
 		let hash = true;
 
 		if (!user) {
@@ -14,7 +14,7 @@ export default ((app, db) => {
 		}
 
 		try {
-			await notifications.unsubscribe(db, user, hash, req.body.scopes);
+			await notifications.unsubscribe(db, user!, hash, req.body.scopes);
 			api.success(res);
 		} catch (err) {
 			api.error(res, err);

--- a/src/routes/stickynotesAPI.ts
+++ b/src/routes/stickynotesAPI.ts
@@ -1,21 +1,22 @@
 import * as api from '../libs/api';
+import * as jwt from '../libs/jwt';
 import * as stickynotes from '../libs/stickynotes';
 import RoutesFunction from './routesFunction';
 
 export default ((app, db) => {
 
-	app.get('/stickynotes', async (req, res) => {
+	app.get('/stickynotes', jwt.requireLoggedIn, async (req, res) => {
 		try {
-			const note = await stickynotes.get(db, req.user.user, req.query.moduleId);
+			const note = await stickynotes.get(db, req.apiUser!, req.query.moduleId);
 			api.success(res, note);
 		} catch (err) {
 			api.error(res, err);
 		}
 	});
 
-	app.put('/stickynotes', async (req, res) => {
+	app.put('/stickynotes', jwt.requireLoggedIn, async (req, res) => {
 		try {
-			await stickynotes.post(db, req.user.user, req.body.moduleId, req.body.text);
+			await stickynotes.post(db, req.apiUser!, req.body.moduleId, req.body.text);
 			api.success(res);
 		} catch (err) {
 			api.error(res, err);


### PR DESCRIPTION
This PR removes `express-jwt` as a dependency and directly uses the `jsonwebtoken` to validate JWTs ourselves. Resolves #104.