### PR TITLE
Route-level API validation + remove redundant checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[package.json]
+[{package,tsconfig}.json]
 indent_style = space
 indent_size = 2

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
 	"watch": "src/**/*.ts",
 	"ext": "ts",
-	"exec": "ts-node --files src/index.ts"
+	"exec": "ts-node -C ttypescript --files src/index.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4249,6 +4249,11 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5615,6 +5620,12 @@
         "resolve": "^1.1.6"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "optional": true
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -6522,6 +6533,14 @@
         "tslib": "^1.8.1"
       }
     },
+    "ttypescript": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.8.tgz",
+      "integrity": "sha512-uXye71UE5iPDOA3mDN9UUtconKGYwjg6m2UgnxVJYyCItE+MliSCZ4kf2asjpJsJQtgPKyu9iAaC4ero1UIbwQ==",
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6639,6 +6658,26 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
+    },
+    "typescript-is": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/typescript-is/-/typescript-is-0.13.1.tgz",
+      "integrity": "sha512-6YyH2EcPI512hpoS9JxIOI9LdG7lG2EkEeeRdTDXIAYBjAJ626AOFziq9+AbNiWBml5BoaVAofHuX5i1rlnO6w==",
+      "requires": {
+        "nested-error-stacks": "^2",
+        "reflect-metadata": ">=0.1.12",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       "dev": true
     },
     "@mymicds/sdk": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@mymicds/sdk/-/sdk-1.7.0.tgz",
-      "integrity": "sha512-kjx7/vWQnPkkz0oqTLeTDs8TvgbI0grtDtMe2Mrr9K7j5uDfjYUktwgYvdMHd9Vu8Krm9QHU0GTbUdRmCDpHVQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@mymicds/sdk/-/sdk-1.8.1.tgz",
+      "integrity": "sha512-2lKW+kLI9lhpxHJFPYDQ2uJdvXYXLyx139GnOQlO2hO6P2FnwYGTqspUm7H7DjzesI6QFKPl/Xh/4Hw5beOcWA==",
       "requires": {
         "es6-promise": "^4.2.5",
         "fetch-everywhere": "^1.0.5",
@@ -81,9 +81,9 @@
       },
       "dependencies": {
         "es6-promise": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-          "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         }
       }
     },
@@ -3036,11 +3036,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
           }
         },
         "form-data": {
@@ -5772,9 +5772,9 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       "dev": true
     },
     "@mymicds/sdk": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@mymicds/sdk/-/sdk-1.8.1.tgz",
-      "integrity": "sha512-2lKW+kLI9lhpxHJFPYDQ2uJdvXYXLyx139GnOQlO2hO6P2FnwYGTqspUm7H7DjzesI6QFKPl/Xh/4Hw5beOcWA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@mymicds/sdk/-/sdk-1.8.2.tgz",
+      "integrity": "sha512-ThS1ccTlZKHEFqhfnhnVfhrXiSgLu3vjgtvOxSKn8E/BUePtjlPooe2ZZwpBjsqhvS39yN65g4e36V8fCKmfvQ==",
       "requires": {
         "es6-promise": "^4.2.5",
         "fetch-everywhere": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "main": "src/index.ts",
   "scripts": {
     "build": "mjml -r src/email/* -o src/html/messages",
-    "start": "npm run build && ts-node --files src/index.ts",
-    "prod": "npm run build && pm2 start ts-node -i max --watch=\"src\" --ignore-watch=\"src/public src/api\" --name=\"mymicds\" -- --files src/index.ts",
-    "tasks": "pm2 start ts-node --watch=\"src\" --ignore-watch=\"src/public src/api\" --name=\"mymicds-tasks\" -- --files src/tasks.ts",
+    "start": "npm run build && ts-node -C ttypescript --files src/index.ts",
+    "prod": "npm run build && pm2 start ts-node -i max --watch=\"src\" --ignore-watch=\"src/public src/api\" --name=\"mymicds\" -- -C ttypescript --files src/index.ts",
+    "tasks": "pm2 start ts-node --watch=\"src\" --ignore-watch=\"src/public src/api\" --name=\"mymicds-tasks\" -- -C ttypescript --files src/tasks.ts",
     "test": "tsc --noEmit",
     "docs": "typedoc --out ./docs --mode modules ./src/libs ./src/external.d.ts",
     "lint": "tslint --project tsconfig.json \"src/**/*.ts\""
@@ -90,7 +90,9 @@
     "request-promise-native": "^1.0.5",
     "socket.io": "^2.3.0",
     "ts-node": "^8.4.1",
+    "ttypescript": "^1.5.8",
     "typescript": "^3.7.2",
+    "typescript-is": "^0.13.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://mymicds.net",
   "dependencies": {
-    "@mymicds/sdk": "^1.8.1",
+    "@mymicds/sdk": "^1.8.2",
     "@types/bcrypt": "^3.0.0",
     "@types/cheerio": "^0.22.13",
     "@types/cors": "^2.8.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://mymicds.net",
   "dependencies": {
-    "@mymicds/sdk": "^1.7.0",
+    "@mymicds/sdk": "^1.8.1",
     "@types/bcrypt": "^3.0.0",
     "@types/cheerio": "^0.22.13",
     "@types/cors": "^2.8.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,14 @@ MongoClient.connect(config.mongodb.uri).then(async (client: MongoClient) => {
 	// Enable admin overrides
 	app.use(api.adminOverride);
 
+	// Synchronous error handler
+	app.use(((err, req, res, next) => {
+		if (res.headersSent) {
+			return next(err);
+		}
+		api.error(res, err);
+	}) as express.ErrorRequestHandler);
+
 	// Require all routes
 	const routes = await Promise.all<RoutesFunction>([
 		'alias',

--- a/src/libs/admins.ts
+++ b/src/libs/admins.ts
@@ -9,8 +9,6 @@ import { UserDoc } from './users';
  * @returns Array of usernames of all admins.
  */
 async function getAdmins(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const userdata = db.collection<UserDoc>('users');
 
 	try {
@@ -26,8 +24,6 @@ async function getAdmins(db: Db) {
  * @param message Email message to send.
  */
 async function sendAdminEmail(db: Db, message: mail.Message) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	// Get admin objects
 	let admins: UserDoc[];
 	try {

--- a/src/libs/aliases.ts
+++ b/src/libs/aliases.ts
@@ -66,9 +66,6 @@ async function addAlias(db: Db, user: string, type: AliasType, classString: stri
  * @returns Object containing all aliases for each alias type.
  */
 async function listAliases(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	// Make sure valid user
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
@@ -107,9 +104,6 @@ async function listAliases(db: Db, user: string) {
  * @returns Object containing all classes for each alias type.
  */
 async function mapAliases(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const [aliases, theClasses] = await Promise.all([
 		listAliases(db, user),
 		classes.get(db, user)
@@ -179,9 +173,6 @@ async function deleteAlias(db: Db, user: string, type: AliasType, aliasId: strin
 async function getAliasClass(db: Db, user: string, type: AliasType, classInput: string) {
 	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
 	if (!aliasTypes.includes(type)) { throw new Error('Invalid alias type!'); }
-
-	// If class input is invalid, just return current value in case it is already a class object
-	if (typeof classInput !== 'string') { return { hasAlias: false, classObject: classInput }; }
 
 	// Make sure valid user
 	const { isUser, userDoc } = await users.get(db, user);

--- a/src/libs/aliases.ts
+++ b/src/libs/aliases.ts
@@ -16,11 +16,6 @@ const aliasTypes: AliasType[] = Object.values(AliasType);
  * @returns ID of the inserted alias.
  */
 async function addAlias(db: Db, user: string, type: AliasType, classString: string, classId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (!aliasTypes.includes(type)) { throw new Error('Invalid alias type!'); }
-	if (typeof classString !== 'string') { throw new Error('Invalid class string!'); }
-	if (typeof classId !== 'string') { await new Error('Invalid class id!'); }
-
 	// Make sure valid user
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
@@ -150,9 +145,6 @@ async function mapAliases(db: Db, user: string) {
  * @param aliasId ID of alias to delete.
  */
 async function deleteAlias(db: Db, user: string, type: AliasType, aliasId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (!aliasTypes.includes(type)) { throw new Error('Invalid alias type!'); }
-
 	// Make sure valid alias
 	const aliases = await listAliases(db, user);
 

--- a/src/libs/aliases.ts
+++ b/src/libs/aliases.ts
@@ -4,8 +4,6 @@ import * as classes from './classes';
 import { MyMICDSClassWithIDs } from './classes';
 import * as users from './users';
 
-const aliasTypes: AliasType[] = Object.values(AliasType);
-
 /**
  * Adds an alias that connects a remote class to a local class object.
  * @param db Database connection.
@@ -171,9 +169,6 @@ async function deleteAlias(db: Db, user: string, type: AliasType, aliasId: strin
  * 			else returns the inputted class.
  */
 async function getAliasClass(db: Db, user: string, type: AliasType, classInput: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (!aliasTypes.includes(type)) { throw new Error('Invalid alias type!'); }
-
 	// Make sure valid user
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
@@ -210,8 +205,6 @@ async function getAliasClass(db: Db, user: string, type: AliasType, classInput: 
  * @param db Database connection.
  */
 export async function deleteClasslessAliases(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const aliasdata = db.collection<AliasWithIDs>('aliases');
 
 	let classless: AliasWithIDs[];

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -59,7 +59,7 @@ function respondSuccess(res: Response, data: any = {}, action: Action | null = n
 function respondError(res: Response, error: Error | string | null, action: Action | null = null) {
 	// Check for different types of errors
 	let err = null;
-	if (error !== null && typeof error === 'object' && typeof error.message === 'string') {
+	if (error !== null && typeof error === 'object') {
 		err = error.message;
 	}
 	if (typeof error === 'string') {

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -20,12 +20,7 @@ import { Omit } from './utils';
  * @param comment Comment to associate with the JWT.
  * @returns JWT or human-readable error message.
  */
-export async function login(db: Db, user: string, password: string, rememberMe: boolean, comment: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof password !== 'string') { throw new Error('Invalid password!'); }
-	if (typeof rememberMe !== 'boolean') { rememberMe = true; }
-
+export async function login(db: Db, user: string, password: string, rememberMe: boolean, comment?: string) {
 	user = user.toLowerCase();
 
 	const { matches, confirmed } = await passwords.passwordMatches(db, user, password);
@@ -57,22 +52,13 @@ export async function login(db: Db, user: string, password: string, rememberMe: 
  * @param db Database connection.
  * @param user User object.
  */
-// tslint:disable-next-line:max-line-length
-export async function register(db: Db, user: Omit<RegisterParameters, 'teacher' | 'gradYear'> & { gradYear: number | null }) {
-	// Validate inputs
-	if (typeof db   !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'object') { throw new Error('Invalid user object!'); }
-	if (typeof user.user !== 'string') { throw new Error('Invalid username!'); }
-
+export async function register(db: Db, user: NewUserData) {
 	// Make sure username is lowercase
 	user.user = user.user.toLowerCase();
 
-	if (typeof user.password  !== 'string' || passwords.passwordBlacklist.includes(user.password)) {
+	if (passwords.passwordBlacklist.includes(user.password)) {
 		throw new Error('Invalid password!');
 	}
-
-	if (typeof user.firstName !== 'string') { throw new Error('Invalid first name!'); }
-	if (typeof user.lastName  !== 'string') { throw new Error('Invalid last name!'); }
 
 	// If gradYear not valid, default to faculty
 	if (typeof user.gradYear !== 'number' || user.gradYear % 1 !== 0 || _.isNaN(user.gradYear)) {
@@ -158,10 +144,6 @@ export async function register(db: Db, user: Omit<RegisterParameters, 'teacher' 
  * @param hash Confirmation hash.
  */
 export async function confirm(db: Db, user: string, hash: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof hash !== 'string') { throw new Error('Invalid hash!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -181,3 +163,5 @@ export async function confirm(db: Db, user: string, hash: string) {
 		throw new Error('Hash not valid!');
 	}
 }
+
+export type NewUserData = Omit<RegisterParameters, 'teacher' | 'gradYear'> & { gradYear: number | null };

--- a/src/libs/backgrounds.ts
+++ b/src/libs/backgrounds.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import { promisify } from 'util';
 import config from './config';
 import { UserDoc } from './users';
-import * as utils from './utils';
 
 // Valid MIME Types for image backgrounds
 const validMimeTypes: { [mime: string]: string } = {

--- a/src/libs/backgrounds.ts
+++ b/src/libs/backgrounds.ts
@@ -80,6 +80,7 @@ function uploadBackground() {
 				return;
 			}
 			const extension = validMimeTypes[file.mimetype];
+			// noinspection SuspiciousTypeOfGuard
 			if (typeof extension !== 'string') {
 				cb(new Error('Invalid file type!'), false);
 				return;
@@ -98,8 +99,6 @@ function uploadBackground() {
  * @returns Path of image directory and the extension for the images.
  */
 async function getCurrentFiles(user: string) {
-	if (typeof user !== 'string' || !utils.validFilename(user)) { throw new Error('Invalid username!'); }
-
 	let userDirs: string[];
 	try {
 		userDirs = await fs.readdir(userBackgroundsDir);
@@ -145,8 +144,6 @@ async function getCurrentFiles(user: string) {
  * @param user Username.
  */
 async function deleteBackground(user: string) {
-	if (typeof user !== 'string' || !utils.validFilename(user)) { throw new Error('Invalid username!'); }
-
 	// Find out user's current directory
 	const { dirname, extension } = await getCurrentFiles(user);
 
@@ -168,8 +165,8 @@ async function deleteBackground(user: string) {
  * @param user Username.
  * @returns All the different variants of a background image and whether or not it's the default background.
  */
-async function getBackground(user: string): Promise<BackgroundObject> {
-	if (typeof user !== 'string' || !utils.validFilename(user)) { return { variants: defaultVariants, hasDefault: true }; }
+async function getBackground(user: string | null): Promise<BackgroundObject> {
+	if (typeof user !== 'string') { return { variants: defaultVariants, hasDefault: true }; }
 
 	// Get user's extension
 	const { dirname, extension } = await getCurrentFiles(user);
@@ -283,12 +280,6 @@ async function getDirExtension(userDir: string) {
  * @param blurRadius Gaussian blur radius to use.
  */
 async function addBlur(fromPath: string, toPath: string, blurRadius: number) {
-	if (typeof fromPath !== 'string') { throw new Error('Invalid path to original image!'); }
-	if (typeof toPath !== 'string') { throw new Error('Invalid path to blurred image!'); }
-	if (typeof blurRadius !== 'number') {
-		blurRadius = defaultBlurRadius;
-	}
-
 	let image: any; // There is a `Jimp` type but there's like two different ones that conflict I guess?
 	try {
 		image = await Jimp.read(fromPath);
@@ -308,8 +299,6 @@ async function addBlur(fromPath: string, toPath: string, blurRadius: number) {
  * @param user Username.
  */
 export async function blurUser(user: string) {
-	if (typeof user !== 'string' || !utils.validFilename(user)) { throw new Error('Invalid username!'); }
-
 	const { dirname, extension } = await getCurrentFiles(user);
 
 	if (dirname === null || extension === null) { return; }

--- a/src/libs/backgrounds.ts
+++ b/src/libs/backgrounds.ts
@@ -187,8 +187,6 @@ async function getBackground(user: string | null): Promise<BackgroundObject> {
  * @returns Each user paired with their background variants.
  */
 async function getAllBackgrounds(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	let userDirs: string[];
 	try {
 		userDirs = await fs.readdir(userBackgroundsDir);

--- a/src/libs/blockSchedule.ts
+++ b/src/libs/blockSchedule.ts
@@ -19,12 +19,12 @@ const middleschoolSchedule = {
 /**
  * Gets the generic schedule for a user depending on their grade.
  * @param date Date to set class start and end times relative to.
- * @param grade User's grade (only middle and upper school grades supported).
- * @param day Schedule rotation day to get the schedule for.
+ * @param grade User's grade (only middle and upper school grades supported), null if teacher.
+ * @param day Schedule rotation day to get the schedule for, null if no rotation.
  * @param lateStart Whether or not the schedule should be late start.
  * @returns The appropriate generic schedule.
  */
-function getSchedule(date: Date | moment.Moment | null, grade: number, day: number, lateStart: boolean) {
+function getSchedule(date: Date | moment.Moment | null, grade: number | null, day: number | null, lateStart: boolean) {
 	// Validate inputs
 	if (date) {
 		date = moment(date);
@@ -37,7 +37,6 @@ function getSchedule(date: Date | moment.Moment | null, grade: number, day: numb
 	if (typeof day !== 'number' || _.isNaN(day) || 1 > day || day > 6) {
 		return null;
 	}
-	lateStart = !!lateStart;
 
 	const schoolName = users.gradeToSchool(grade);
 

--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -22,8 +22,6 @@ const urlPrefix = 'https://micds.instructure.com/feeds/calendars/';
  * @returns Whether the URL is valid and a newly formatted URL if it is.
  */
 export async function verifyURL(canvasURL: string) {
-	if (typeof canvasURL !== 'string') { throw new Error('Invalid URL!'); }
-
 	// Parse URL first
 	const parsedURL = url.parse(canvasURL);
 
@@ -62,8 +60,6 @@ export async function verifyURL(canvasURL: string) {
  * @returns Whether the URL is valid.
  */
 export async function setURL(db: Db, user: string, calUrl: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 

--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -176,9 +176,6 @@ function calendarToEvent(calLink: string) {
  * @returns Whether the user has a saved URL and the associated classes.
  */
 export async function getClasses(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -235,9 +232,6 @@ export async function getClasses(db: Db, user: string) {
  * @returns Whether the user has a saved URL and the cache events.
  */
 export async function getFromCache(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 

--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -86,8 +86,6 @@ export async function setURL(db: Db, user: string, calUrl: string) {
  * @returns Whether the user has a saved URL and the calendar events.
  */
 export async function getUserCal(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -335,8 +333,6 @@ export async function getFromCache(db: Db, user: string) {
  * @returns An object mapping Canvas class IDs to arrays of Canvas assignment names.
  */
 export async function getUniqueEvents(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const canvasdata = db.collection<CanvasCacheEvent>('canvasFeeds');
 	const docs = await canvasdata.aggregate([
 		{

--- a/src/libs/checkedEvents.ts
+++ b/src/libs/checkedEvents.ts
@@ -38,10 +38,6 @@ async function checkEvent(db: Db, user: string, eventId: string) {
  * @param eventId Event ID to check.
  */
 async function getChecked(db: Db, user: string, eventId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof eventId !== 'string') { throw new Error('Invalid event id!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -64,9 +60,6 @@ async function getChecked(db: Db, user: string, eventId: string) {
  * @returns A list of checked events.
  */
 async function listChecked(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 

--- a/src/libs/checkedEvents.ts
+++ b/src/libs/checkedEvents.ts
@@ -8,10 +8,6 @@ import * as users from './users';
  * @param eventId Event ID to check off.
  */
 async function checkEvent(db: Db, user: string, eventId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof eventId !== 'string') { throw new Error('Invalid event id!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -94,10 +90,6 @@ async function listChecked(db: Db, user: string) {
  * @param eventId Event ID to uncheck.
  */
 async function uncheckEvent(db: Db, user: string, eventId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof eventId !== 'string') { throw new Error('Invalid event id!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 

--- a/src/libs/cryptoUtils.ts
+++ b/src/libs/cryptoUtils.ts
@@ -21,11 +21,6 @@ export async function hashPassword(password: string) {
  * @returns Whether the strings match.
  */
 export function safeCompare(a: string, b: string) {
-
-	if (typeof a !== 'string' || typeof b !== 'string') {
-		return false;
-	}
-
 	let mismatch = (a.length === b.length ? 0 : 1);
 	if (mismatch) {
 		b = a;

--- a/src/libs/dates.ts
+++ b/src/libs/dates.ts
@@ -10,11 +10,6 @@ import * as portal from './portal';
  * @returns A Moment.js object with the start of school.
  */
 export function thirdWednesdayAugust(year: number) {
-	const current = moment();
-	if (typeof year !== 'number' || year % 1 !== 0) {
-		year = current.year();
-	}
-
 	return moment().year(year).month('August').startOf('month').day('Wednesday').add(2, 'weeks').startOf('day').hours(8);
 }
 

--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -13,8 +13,6 @@ import * as users from './users';
  * @param user Username.
  */
 export async function updateCanvasCache(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const canvasdata = db.collection('canvasFeeds');
 
 	const { isUser, userDoc } = await users.get(db, user);
@@ -48,8 +46,6 @@ export async function updateCanvasCache(db: Db, user: string) {
  * @returns The events that are *currently* in the Portal classes cache, or null if there's no URL.
  */
 export async function addPortalQueueClasses(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -110,8 +106,6 @@ export async function addPortalQueueClasses(db: Db, user: string) {
  * @returns The events that are *currently* in the Portal calendar cache, or null if there's no URL.
  */
 export async function addPortalQueueCalendar(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -170,8 +164,6 @@ export async function addPortalQueueCalendar(db: Db, user: string) {
  * @param db Database connection.
  */
 export async function processPortalQueue(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const userdata = db.collection<UserDoc>('users');
 
 	let queue: UserDoc[];

--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -188,22 +188,6 @@ export async function processPortalQueue(db: Db) {
 }
 
 /**
- * Tries to get Canvas calendar from cache. If it's empty, it tries updating the cache and returning that response.
- * @param {Object} db - Database object
- * @param {string} user - Username
- * @param {canvasCacheRetryCallback} callback - Callback
- */
-
-/**
- * Returns array containing Canvas events
- * @callback canvasCacheRetryCallback
- *
- * @param {Object} err - Null if success, error object if failure
- * @param {Boolean} hasURL - Whether or not user has a Canvas URL set. Null if error.
- * @param {Array} events - Array of events if success, null if failure.
- */
-
-/**
  * Checks the Canvas cache for a user. If there's no cache data, updates the cache.
  * @param db Database connection.
  * @param user Username.

--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -11,10 +11,7 @@ import { StringDict } from './utils';
 declare global {
 	namespace Express {
 		interface Request {
-			user: false | {
-				user: string;
-				scopes: { [scope: string]: true };
-			};
+			user: false | UserPayload;
 		}
 	}
 }
@@ -177,9 +174,7 @@ export function requireScope(
  * @param comment Comment to associate with the JWT.
  * @returns A valid JWT.
  */
-export async function generate(db: Db, user: string, rememberMe: boolean, comment: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
+export async function generate(db: Db, user: string, rememberMe: boolean, comment?: string) {
 	const expiration = rememberMe ? '30 days' : '12 hours';
 
 	const { isUser, userDoc } = await users.get(db, user);
@@ -255,11 +250,7 @@ export async function isBlacklisted(db: Db, checkJwt: string) {
  * @param payload All the JWT claims and payload.
  * @param revokeJwt The JWT to revoke access for.
  */
-export async function revoke(db: Db, payload: any, revokeJwt: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof payload !== 'object') { throw new Error('Invalid payload!'); }
-	if (typeof revokeJwt !== 'string') { throw new Error('Invalid JWT!'); }
-
+export async function revoke(db: Db, payload: UserPayload, revokeJwt: string) {
 	const { isUser, userDoc } = await users.get(db, payload.user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -278,4 +269,9 @@ export interface JWTDoc {
 	jwt: string;
 	comment: string;
 	lastUsed: Date;
+}
+
+export interface UserPayload {
+	user: string;
+	scopes: { [scope: string]: true };
 }

--- a/src/libs/jwt.ts
+++ b/src/libs/jwt.ts
@@ -228,9 +228,6 @@ export async function generate(db: Db, user: string, rememberMe: boolean, commen
  * @returns Whether the JWT is blacklisted.
  */
 export async function isBlacklisted(db: Db, checkJwt: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof checkJwt !== 'string') { throw new Error('Invalid JWT!'); }
-
 	const jwtData = db.collection<JWTDoc>('jwtWhitelist');
 
 	let docs: JWTDoc[];

--- a/src/libs/lunch.ts
+++ b/src/libs/lunch.ts
@@ -62,6 +62,7 @@ async function getLunch(db: Db, date: Date) {
 
 /**
  * Parses Flik's JSON data into our API
+ * @param school The school to get data for.
  * @param body HTML body of the page.
  * @returns An object with the lunch data.
  */

--- a/src/libs/lunch.ts
+++ b/src/libs/lunch.ts
@@ -19,8 +19,6 @@ const schools: Record<School, string> = {
  * @param date Date to get the lunch for.
  */
 async function getLunch(db: Db, date: Date) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const currentDay = moment(date).day('Wednesday');
 	const fullLunchResponse: GetLunchResponse['lunch'] = {};
 

--- a/src/libs/mail.ts
+++ b/src/libs/mail.ts
@@ -12,12 +12,6 @@ import { StringDict } from './utils';
  * @param transporter Nodemailer transport object.
  */
 export async function send(users: string | string[], message: Message, transporter?: nodemailer.Transporter) {
-	// Validate inputs
-	if (typeof users !== 'string' && typeof users !== 'object') { throw new Error('Invalid user(s)!'); }
-	if (typeof message !== 'object') { throw new Error('Invalid message object!'); }
-	if (typeof message.subject !== 'string') { throw new Error('Invalid mail subject!'); }
-	if (typeof message.html !== 'string') { throw new Error('Invalid mail html!'); }
-
 	if (typeof transporter !== 'object') {
 		transporter = nodemailer.createTransport(config.email.URI);
 	}
@@ -46,9 +40,6 @@ export async function send(users: string | string[], message: Message, transport
  */
 // tslint:disable-next-line:max-line-length
 export async function sendHTML(users: string | string[], subject: string, file: string, data: StringDict, transporter?: nodemailer.Transporter) {
-	if (typeof file !== 'string') { throw new Error('Invalid mail file path!'); }
-	if (typeof data !== 'object') { data = {}; }
-
 	let body;
 	try {
 		body = await fs.readFile(file, 'utf8');

--- a/src/libs/modules.ts
+++ b/src/libs/modules.ts
@@ -154,9 +154,6 @@ function getDefaultOptions(type: MyMICDSModuleType): any {
  * @returns A list of module objects.
  */
 async function getModules(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	// Check for user validity, get ID
 	const { isUser, userDoc } = await users.get(db, user);
 
@@ -204,15 +201,6 @@ async function getModules(db: Db, user: string) {
  * @param modules The module objects to modify.
  */
 async function upsertModules(db: Db, user: string, modules: MyMICDSModule[]) {
-	// Input validation
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
-	if (!_.isArray(modules)) { throw new Error('Modules is not an array!'); }
-	if (!modules.every(m => Object.values(MyMICDSModuleType).includes(m.type))) {
-		throw new Error('Invalid module type!');
-	}
-
 	for (const mod of modules) {
 		const optionsConfig = modulesConfig[mod.type];
 
@@ -256,7 +244,7 @@ async function upsertModules(db: Db, user: string, modules: MyMICDSModule[]) {
 			} else if (typeof moduleValue === configType) {
 				// Check if native primitive type
 				valid = true;
-			} else if (moduleValue instanceof (configType as Constructor)) {
+			} else if ((configType as Constructor).prototype && moduleValue instanceof (configType as Constructor)) {
 				// Check if native object type
 				valid = true;
 			}

--- a/src/libs/modules.ts
+++ b/src/libs/modules.ts
@@ -135,7 +135,7 @@ const defaultModules: MyMICDSModule[] = [
  * @returns The default module configuration options.
  */
 function getDefaultOptions(type: MyMICDSModuleType): any {
-	const moduleConfig = modulesConfig[type as MyMICDSModuleType];
+	const moduleConfig = modulesConfig[type];
 	if (typeof moduleConfig === 'undefined') {
 		return {};
 	}

--- a/src/libs/notifications.ts
+++ b/src/libs/notifications.ts
@@ -1,12 +1,7 @@
+import { Scope } from '@mymicds/sdk';
 import { Db } from 'mongodb';
 import * as cryptoUtils from './cryptoUtils';
 import * as users from './users';
-
-export enum Scope {
-	ALL = 'ALL',
-	ANNOUNCEMENTS = 'ANNOUNCEMENTS',
-	FEATURES = 'FEATURES'
-}
 
 /**
  * Unsubscribes a user from a certain set of emails.
@@ -15,18 +10,8 @@ export enum Scope {
  * @param hash Unsubscription hash.
  * @param scopes Scope(s) to unsubscribe from.
  */
-export async function unsubscribe(db: Db, user: string, hash: string | boolean, scopes: Scope | Scope[]) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-	if (typeof hash !== 'string' && hash !== true) { throw new Error('Invalid hash!'); }
-	if (typeof scopes !== 'string' && typeof scopes !== 'object') { throw new Error('Invalid scope(s)!'); }
-
+export async function unsubscribe(db: Db, user: string, hash: string | true, scopes: Scope | Scope[]) {
 	if (typeof scopes === 'string') { scopes = [scopes]; }
-	for (const scope of scopes) {
-		if (!Object.values(Scope).includes(scope)) {
-			throw new Error(`"${scope}" is an invalid email type!`);
-		}
-	}
 
 	// Make sure valid user and get user id
 	const { isUser, userDoc } = await users.get(db, user);

--- a/src/libs/passwords.ts
+++ b/src/libs/passwords.ts
@@ -47,10 +47,7 @@ export async function passwordMatches(db: Db, user: string, password: string) {
  * @param newPassword The new password to set.
  */
 export async function changePassword(db: Db, user: string, oldPassword: string, newPassword: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof newPassword !== 'string') { throw new Error('Invalid new password!'); }
-
-	if (typeof oldPassword !== 'string' || passwordBlacklist.includes(newPassword)) {
+	if (passwordBlacklist.includes(newPassword)) {
 		throw new Error('Invalid old password!');
 	}
 
@@ -79,8 +76,6 @@ export async function changePassword(db: Db, user: string, oldPassword: string, 
  * @param user Username.
  */
 export async function resetPasswordEmail(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -128,9 +123,7 @@ export async function resetPasswordEmail(db: Db, user: string) {
  * @param hash The reset hash.
  */
 export async function resetPassword(db: Db, user: string, password: string, hash: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof password !== 'string' || passwordBlacklist.includes(password)) { throw new Error('Invalid password!'); }
-	if (typeof hash !== 'string') { throw new Error('Invalid hash!'); }
+	if (passwordBlacklist.includes(password)) { throw new Error('Invalid password!'); }
 
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }

--- a/src/libs/passwords.ts
+++ b/src/libs/passwords.ts
@@ -127,7 +127,7 @@ export async function resetPassword(db: Db, user: string, password: string, hash
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
-	if (typeof userDoc!.passwordChangeHash !== 'string' || userDoc!.passwordChangeHash === null) {
+	if (typeof userDoc!.passwordChangeHash !== 'string') {
 		throw new Error('Password change email was never sent!');
 	}
 

--- a/src/libs/passwords.ts
+++ b/src/libs/passwords.ts
@@ -20,9 +20,6 @@ export const passwordBlacklist = [
  * @returns Whether the password matched and whether the user's account is confirmed.
  */
 export async function passwordMatches(db: Db, user: string, password: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof password !== 'string') { throw new Error('Invalid password!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	// If invalid user, we just want to say username / password doesn't match
 	if (!isUser) { return { matches: false, confirmed: false }; }

--- a/src/libs/passwords.ts
+++ b/src/libs/passwords.ts
@@ -33,7 +33,7 @@ export async function passwordMatches(db: Db, user: string, password: string) {
 		throw new Error('There was a problem comparing the passwords!');
 	}
 
-	return { matches: res, confirmed: !!userDoc!.confirmed };
+	return { matches: res, confirmed: userDoc!.confirmed };
 }
 
 /**

--- a/src/libs/planner.ts
+++ b/src/libs/planner.ts
@@ -11,19 +11,10 @@ import { Omit } from './utils';
  * @param user Username.
  * @param plannerEvent Planner event object.
  */
-// tslint:disable-next-line:max-line-length
-async function upsertEvent(db: Db, user: string, plannerEvent: Omit<PlannerInputEvent, 'user' | 'link'> & { link?: string }) {
-	// Validate inputs
-	if (typeof db   !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid user!'); }
-
-	if (typeof plannerEvent         !== 'object') { throw new Error('Invalid event object!'); }
+async function upsertEvent(db: Db, user: string, plannerEvent: NewEventData) {
+	// Defaults
 	if (typeof plannerEvent._id     !== 'string') { plannerEvent._id = ''; }
-	if (typeof plannerEvent.title   !== 'string') { throw new Error('Invalid event title!'); }
-	if (typeof plannerEvent.desc    !== 'string') { plannerEvent.desc = ''; }
 	if (typeof plannerEvent.classId !== 'string') { plannerEvent.classId = null; }
-	if (typeof plannerEvent.start   !== 'object') { throw new Error('Invalid event start!'); }
-	if (typeof plannerEvent.end     !== 'object') { throw new Error('Invalid event end!'); }
 	if (typeof plannerEvent.link    !== 'string') { plannerEvent.link = ''; }
 
 	// Made sure start time and end time are consecutive or the same
@@ -101,9 +92,6 @@ async function upsertEvent(db: Db, user: string, plannerEvent: Omit<PlannerInput
  * @param eventId Event ID to delete.
  */
 async function deleteEvent(db: Db, user: string, eventId: string) {
-	if (typeof db   !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid user!'); }
-
 	// Try to create object id
 	let id: ObjectID;
 	try {
@@ -133,9 +121,6 @@ async function deleteEvent(db: Db, user: string, eventId: string) {
  * @returns A list of planner documents, including teacher information.
  */
 async function getEvents(db: Db, user: string) {
-	if (typeof db   !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid user!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -223,7 +208,7 @@ export interface BasePlannerEvent {
 }
 
 export interface PlannerInputEvent extends BasePlannerEvent {
-	_id: string;
+	_id?: string;
 	classId?: string | null;
 }
 
@@ -231,6 +216,8 @@ export interface PlannerDBEvent extends BasePlannerEvent {
 	_id: ObjectID;
 	class: ObjectID;
 }
+
+export type NewEventData = Omit<PlannerInputEvent, 'user' | 'link'> & { link?: string };
 
 export {
 	upsertEvent as upsert,

--- a/src/libs/portal.ts
+++ b/src/libs/portal.ts
@@ -45,6 +45,7 @@ async function verifyURLGeneric(portalURL: string) {
 
 	const pathID = parsedURL.pathname.split('/')[3];
 
+	// noinspection SuspiciousTypeOfGuard
 	if (typeof pathID !== 'string' && typeof params.get('uid') !== 'string') {
 		throw new Error('URL does not contain calendar ID!');
 	}
@@ -177,9 +178,6 @@ export async function setURLCalendar(db: Db, user: string, calUrl: string) {
  * @returns Whether the user has a saved URL and the cache events.
  */
 export async function getFromCacheClasses(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -204,9 +202,6 @@ export async function getFromCacheClasses(db: Db, user: string) {
  * @returns Whether the user has a saved URL and the cache events.
  */
 export async function getFromCacheCalendar(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -231,9 +226,6 @@ export async function getFromCacheCalendar(db: Db, user: string) {
  * @returns Whether the user has a saved URL and the calendar events.
  */
 export async function getFromCalClasses(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -264,9 +256,6 @@ export async function getFromCalClasses(db: Db, user: string) {
  * @returns Whether the user has a saved URL and the calendar events.
  */
 export async function getFromCalCalendar(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
@@ -389,9 +378,6 @@ export async function getDayRotations() {
  * @returns A list of Portal class names.
  */
 export async function getClasses(db: Db, user: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const { hasURL, events } = await getFromCacheClasses(db, user);
 	if (!hasURL) { return { hasURL: false, classes: null }; }
 
@@ -468,7 +454,6 @@ function parsePortalClasses(events: PortalCacheEvent[]) {
  * @returns A more-readable event title.
  */
 export function cleanUp(str: string) {
-	if (typeof str !== 'string') { return str; }
 	return str.replace(cleanUpBlockSuffix, '');
 }
 

--- a/src/libs/portal.ts
+++ b/src/libs/portal.ts
@@ -33,8 +33,6 @@ export const portalRange = {
  * @returns Whether the URL is valid, a formatted URL, and the response body.
  */
 async function verifyURLGeneric(portalURL: string) {
-	if (typeof portalURL !== 'string') { throw new Error('Invalid URL!'); }
-
 	// Parse URL first
 	const parsedURL = new URL(portalURL);
 
@@ -127,13 +125,11 @@ export async function verifyURLCalendar(portalURL: string) {
  * @param calUrl Whether the URL is valid and a formatted URL.
  */
 export async function setURLClasses(db: Db, user: string, calUrl: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
 	const { isValid, url: validURL } = await verifyURLClasses(calUrl);
-	if (isValid !== true) { return { isValid, validURL: null }; }
+	if (!isValid) { return { isValid, validURL: null }; }
 
 	const userdata = db.collection('users');
 
@@ -155,13 +151,11 @@ export async function setURLClasses(db: Db, user: string, calUrl: string) {
  * @param calUrl Whether the URL is valid and a formatted URL.
  */
 export async function setURLCalendar(db: Db, user: string, calUrl: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }
 
 	const { isValid, url: validURL } = await verifyURLCalendar(calUrl);
-	if (isValid !== true) { return { isValid, validURL: null }; }
+	if (!isValid) { return { isValid, validURL: null }; }
 
 	const userdata = db.collection('users');
 

--- a/src/libs/quotes.ts
+++ b/src/libs/quotes.ts
@@ -7,8 +7,6 @@ import { Db } from 'mongodb';
  * @returns A list of all saved quotes.
  */
 async function getQuotes(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const quotesData = db.collection<Quote>('quotes');
 
 	try {

--- a/src/libs/quotes.ts
+++ b/src/libs/quotes.ts
@@ -25,10 +25,6 @@ async function getQuotes(db: Db) {
  * @param quote Quote content.
  */
 async function insertQuote(db: Db, author: string, quote: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof author !== 'string') { throw new Error('Invalid author!'); }
-	if (typeof quote !== 'string') { throw new Error('Invalid quote!'); }
-
 	const quotesData = db.collection('quotes');
 
 	try {

--- a/src/libs/schedule.ts
+++ b/src/libs/schedule.ts
@@ -163,7 +163,7 @@ async function getSchedule(db: Db, user: string, date: Date, portalBroke = false
 
 	// Determine when school should start and end for a default schedule
 	let lateStart = false;
-	let defaultStart: moment.Moment | null = null;
+	let defaultStart: moment.Moment;
 	if (scheduleDate.day() !== 3) {
 		// Not Wednesday, school starts at 8
 		defaultStart = scheduleDate.clone().hour(8);

--- a/src/libs/schedule.ts
+++ b/src/libs/schedule.ts
@@ -152,8 +152,6 @@ const genericBlocks: Record<
  * 			and the different classes for the day.
  */
 async function getSchedule(db: Db, user: string, date: Date, portalBroke = false) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const scheduleDate = moment(date).startOf('day');
 	const scheduleNextDay = scheduleDate.clone().add(1, 'day');
 

--- a/src/libs/stats.ts
+++ b/src/libs/stats.ts
@@ -9,8 +9,6 @@ import { UserDoc } from './users';
  * @returns An object containing different user statistics.
  */
 async function getStats(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const stats: GetStatsResponse['stats'] = {
 		registered: {
 			total: 0,

--- a/src/libs/stickynotes.ts
+++ b/src/libs/stickynotes.ts
@@ -9,9 +9,6 @@ import * as users from './users';
  * @returns A sticky note object.
  */
 async function getNotes(db: Db, user: string, moduleId: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof moduleId !== 'string') { throw new Error('Invalid moduleId!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('Invalid username!'); }
 
@@ -35,10 +32,6 @@ async function getNotes(db: Db, user: string, moduleId: string) {
  * @param text The content of the sticky note.
  */
 async function postNote(db: Db, user: string, moduleId: string, text: string) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof moduleId !== 'string') { throw new Error('Invalid moduleId!'); }
-	if (typeof text !== 'string') { throw new Error('Invalid note text!'); }
-
 	const { isUser, userDoc } = await users.get(db, user);
 	if (!isUser) { throw new Error('Invalid username!'); }
 

--- a/src/libs/teachers.ts
+++ b/src/libs/teachers.ts
@@ -13,11 +13,7 @@ const validTeacherPrefixes = [
  * @param teacher Teacher object to insert.
  */
 async function addTeacher(db: Db, teacher: Omit<Teacher, '_id'>) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof teacher !== 'object') { throw new Error('Invalid teacher object!'); }
 	if (!validTeacherPrefixes.includes(teacher.prefix)) { throw new Error('Invalid teacher prefix!'); }
-	if (typeof teacher.firstName !== 'string') { throw new Error('Invalid teacher first name!'); }
-	if (typeof teacher.lastName !== 'string') { throw new Error('Invalid teacher last name!'); }
 
 	const teacherdata = db.collection<TeacherWithIDOptional>('teachers');
 

--- a/src/libs/teachers.ts
+++ b/src/libs/teachers.ts
@@ -39,9 +39,6 @@ async function addTeacher(db: Db, teacher: Omit<Teacher, '_id'>) {
  * @returns Whether the object ID points to a valid teacher and the corresponding teacher document.
  */
 async function getTeacher(db: Db, teacherId: ObjectID) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof teacherId !== 'object') { throw new Error('Invalid teacher id object!'); }
-
 	const teacherdata = db.collection<Teacher>('teachers');
 
 	try {
@@ -68,8 +65,6 @@ async function getTeacher(db: Db, teacherId: ObjectID) {
  * @returns A list of all the teacher objects in the database.
  */
 async function listTeachers(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const teacherdata = db.collection<Teacher>('teachers');
 
 	try {
@@ -84,8 +79,6 @@ async function listTeachers(db: Db) {
  * @param db Database connection.
  */
 export async function deleteClasslessTeachers(db: Db) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-
 	const teacherdata = db.collection<Teacher>('teachers');
 
 	let docs: Teacher[];

--- a/src/libs/users.ts
+++ b/src/libs/users.ts
@@ -40,7 +40,7 @@ async function getUser(db: Db, user: string) {
  * @param privateInfo Whether to include more sensitive information like calendar URLs. Defaults to false.
  * @returns An object containing user information.
  */
-export async function getInfo(db: Db, user: string, privateInfo = false) {
+export async function getInfo(db: Db, user: string, privateInfo: boolean) {
 	const { isUser, userDoc } = await getUser(db, user);
 
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }

--- a/src/libs/users.ts
+++ b/src/libs/users.ts
@@ -96,8 +96,6 @@ export async function getInfo(db: Db, user: string, privateInfo = false) {
  * @param info Information to change.
  */
 export async function changeInfo(db: Db, user: string, info: ChangeUserInfoParameters) {
-	if (typeof info !== 'object') { throw new Error('Invalid information!'); }
-
 	// I mean if they want nothing changed, I guess there's no error
 	if (_.isEmpty(info)) { return; }
 

--- a/src/libs/users.ts
+++ b/src/libs/users.ts
@@ -205,7 +205,7 @@ export interface UserDoc {
 	lastLogin?: Date;
 	lastVisited?: Date;
 	lastPasswordChange?: Date;
-	passwordChangeHash?: string;
+	passwordChangeHash?: string | null;
 	portalURL?: string; // Legacy URL
 	portalURLClasses?: string;
 	portalURLCalendar?: string;

--- a/src/libs/users.ts
+++ b/src/libs/users.ts
@@ -12,9 +12,6 @@ import * as dates from './dates';
  * @returns Whether the user is valid and the contents of the user document.
  */
 async function getUser(db: Db, user: string) {
-	if (typeof db !== 'object') {	throw new Error('Invalid database connection!'); }
-	if (typeof user !== 'string') { throw new Error('Invalid username!'); }
-
 	const userdata = db.collection<UserDoc>('users');
 
 	let docs: UserDoc[];
@@ -43,10 +40,7 @@ async function getUser(db: Db, user: string) {
  * @param privateInfo Whether to include more sensitive information like calendar URLs. Defaults to false.
  * @returns An object containing user information.
  */
-export async function getInfo(db: Db, user: string, privateInfo: boolean) {
-	if (typeof db !== 'object') { throw new Error('Invalid database connection!'); }
-	if (typeof privateInfo !== 'boolean') { privateInfo = false; }
-
+export async function getInfo(db: Db, user: string, privateInfo = false) {
 	const { isUser, userDoc } = await getUser(db, user);
 
 	if (!isUser) { throw new Error('User doesn\'t exist!'); }

--- a/src/routes/aliasAPI.ts
+++ b/src/routes/aliasAPI.ts
@@ -1,3 +1,5 @@
+import { AddAliasParameters, DeleteAliasParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as aliases from '../libs/aliases';
 import * as api from '../libs/api';
 import * as jwt from '../libs/jwt';
@@ -7,6 +9,7 @@ export default ((app, db, socketIO) => {
 
 	app.post('/alias', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<AddAliasParameters>(req.body);
 			const aliasId = await aliases.add(db, req.apiUser!, req.body.type, req.body.classString, req.body.classId);
 			socketIO.user(req.apiUser!, 'alias', 'add', {
 				_id: aliasId,
@@ -31,6 +34,7 @@ export default ((app, db, socketIO) => {
 
 	app.delete('/alias', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<DeleteAliasParameters>(req.body);
 			await aliases.delete(db, req.apiUser!, req.body.type, req.body.id);
 			socketIO.user(req.apiUser!, 'alias', 'delete', req.body.id);
 			api.success(res);

--- a/src/routes/authAPI.ts
+++ b/src/routes/authAPI.ts
@@ -1,3 +1,11 @@
+import {
+	ChangePasswordParameters,
+	ConfirmParameters,
+	ForgotPasswordParameters,
+	LoginParameters,
+	RegisterParameters,
+	ResetPasswordParameters
+} from '@mymicds/sdk';
 import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as auth from '../libs/auth';
@@ -20,9 +28,7 @@ export default ((app, db) => {
 		const rememberMe = typeof req.body.remember !== 'undefined';
 
 		try {
-			assertType<string>(req.body.user);
-			assertType<string>(req.body.password);
-			assertType<string | undefined>(req.body.comment);
+			assertType<LoginParameters>(req.body);
 
 			const responseObj = await auth.login(db, req.body.user, req.body.password, rememberMe, req.body.comment);
 			api.success(res, responseObj);
@@ -57,7 +63,7 @@ export default ((app, db) => {
 		}
 
 		try {
-			assertType<auth.NewUserData>(user);
+			assertType<RegisterParameters>(req.body);
 			await auth.register(db, user);
 			api.success(res);
 		} catch (err) {
@@ -67,8 +73,7 @@ export default ((app, db) => {
 
 	app.post('/auth/confirm', async (req, res) => {
 		try {
-			assertType<string>(req.body.user);
-			assertType<string>(req.body.hash);
+			assertType<ConfirmParameters>(req.body);
 			await auth.confirm(db, req.body.user, req.body.hash);
 			api.success(res);
 		} catch (err) {
@@ -78,8 +83,7 @@ export default ((app, db) => {
 
 	app.put('/auth/change-password', jwt.requireLoggedIn, async (req, res) => {
 		try {
-			assertType<string>(req.body.oldPassword);
-			assertType<string>(req.body.newPassword);
+			assertType<ChangePasswordParameters>(req.body);
 			await passwords.changePassword(db, req.apiUser!, req.body.oldPassword, req.body.newPassword);
 			api.success(res);
 		} catch (err) {
@@ -93,7 +97,7 @@ export default ((app, db) => {
 			return;
 		}
 		try {
-			assertType<string>(req.body.user);
+			assertType<ForgotPasswordParameters>(req.body);
 			await passwords.resetPasswordEmail(db, req.body.user);
 			api.success(res);
 		} catch (err) {
@@ -107,9 +111,7 @@ export default ((app, db) => {
 			return;
 		}
 		try {
-			assertType<string>(req.body.user);
-			assertType<string>(req.body.password);
-			assertType<string>(req.body.hash);
+			assertType<ResetPasswordParameters>(req.body);
 			await passwords.resetPassword(db, req.body.user, req.body.password, req.body.hash);
 			api.success(res);
 		} catch (err) {

--- a/src/routes/authAPI.ts
+++ b/src/routes/authAPI.ts
@@ -50,6 +50,13 @@ export default ((app, db) => {
 	});
 
 	app.post('/auth/register', async (req, res) => {
+		try {
+			assertType<RegisterParameters>(req.body);
+		} catch (err) {
+			api.error(res, err);
+			return;
+		}
+
 		const user: auth.NewUserData = {
 			user: req.body.user,
 			password: req.body.password,
@@ -63,7 +70,6 @@ export default ((app, db) => {
 		}
 
 		try {
-			assertType<RegisterParameters>(req.body);
 			await auth.register(db, user);
 			api.success(res);
 		} catch (err) {

--- a/src/routes/authAPI.ts
+++ b/src/routes/authAPI.ts
@@ -1,3 +1,4 @@
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as auth from '../libs/auth';
 import * as jwt from '../libs/jwt';
@@ -19,6 +20,10 @@ export default ((app, db) => {
 		const rememberMe = typeof req.body.remember !== 'undefined';
 
 		try {
+			assertType<string>(req.body.user);
+			assertType<string>(req.body.password);
+			assertType<string | undefined>(req.body.comment);
+
 			const responseObj = await auth.login(db, req.body.user, req.body.password, rememberMe, req.body.comment);
 			api.success(res, responseObj);
 		} catch (err) {
@@ -26,15 +31,12 @@ export default ((app, db) => {
 		}
 	});
 
-	app.post('/auth/logout', async (req, res) => {
-		let token = req.get('Authorization');
-		// If there's a token, we need to get rid of the 'Bearer ' at the beginning
-		if (token) {
-			token = token.slice(7);
-		}
+	app.post('/auth/logout', jwt.requireLoggedIn, async (req, res) => {
+		// Since you must be logged in to log out, there's always going to be a token
+		const token = req.headers.authorization!.slice(7);
 
 		try {
-			await jwt.revoke(db, req.user, token!);
+			await jwt.revoke(db, req.user as jwt.UserPayload, token);
 			api.success(res);
 		} catch (err) {
 			api.error(res, err);
@@ -42,7 +44,7 @@ export default ((app, db) => {
 	});
 
 	app.post('/auth/register', async (req, res) => {
-		const user: any = {
+		const user: auth.NewUserData = {
 			user: req.body.user,
 			password: req.body.password,
 			firstName: req.body.firstName,
@@ -55,6 +57,7 @@ export default ((app, db) => {
 		}
 
 		try {
+			assertType<auth.NewUserData>(user);
 			await auth.register(db, user);
 			api.success(res);
 		} catch (err) {
@@ -64,6 +67,8 @@ export default ((app, db) => {
 
 	app.post('/auth/confirm', async (req, res) => {
 		try {
+			assertType<string>(req.body.user);
+			assertType<string>(req.body.hash);
 			await auth.confirm(db, req.body.user, req.body.hash);
 			api.success(res);
 		} catch (err) {
@@ -73,6 +78,8 @@ export default ((app, db) => {
 
 	app.put('/auth/change-password', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<string>(req.body.oldPassword);
+			assertType<string>(req.body.newPassword);
 			await passwords.changePassword(db, req.apiUser!, req.body.oldPassword, req.body.newPassword);
 			api.success(res);
 		} catch (err) {
@@ -86,6 +93,7 @@ export default ((app, db) => {
 			return;
 		}
 		try {
+			assertType<string>(req.body.user);
 			await passwords.resetPasswordEmail(db, req.body.user);
 			api.success(res);
 		} catch (err) {
@@ -99,6 +107,9 @@ export default ((app, db) => {
 			return;
 		}
 		try {
+			assertType<string>(req.body.user);
+			assertType<string>(req.body.password);
+			assertType<string>(req.body.hash);
 			await passwords.resetPassword(db, req.body.user, req.body.password, req.body.hash);
 			api.success(res);
 		} catch (err) {

--- a/src/routes/backgroundAPI.ts
+++ b/src/routes/backgroundAPI.ts
@@ -1,12 +1,13 @@
 import * as api from '../libs/api';
 import * as backgrounds from '../libs/backgrounds';
+import * as jwt from '../libs/jwt';
 import RoutesFunction from './routesFunction';
 
 export default ((app, db, socketIO) => {
 
 	app.get('/background', async (req, res) => {
 		try {
-			const responseObj = await backgrounds.get(req.apiUser!);
+			const responseObj = await backgrounds.get(req.apiUser);
 			api.success(res, responseObj);
 		} catch (err) {
 			api.error(res, err);
@@ -22,7 +23,7 @@ export default ((app, db, socketIO) => {
 		}
 	});
 
-	app.put('/background', (req, res) => {
+	app.put('/background', jwt.requireLoggedIn, (req, res) => {
 		// Write image to user-backgrounds
 		backgrounds.upload()(req, res, async err => {
 			if (err) {
@@ -49,7 +50,7 @@ export default ((app, db, socketIO) => {
 		});
 	});
 
-	app.delete('/background', async (req, res) => {
+	app.delete('/background', jwt.requireLoggedIn, async (req, res) => {
 		try {
 			await backgrounds.delete(req.apiUser!);
 		} catch (err) {

--- a/src/routes/canvasAPI.ts
+++ b/src/routes/canvasAPI.ts
@@ -1,3 +1,5 @@
+import { SetCanvasURLParameters, TestCanvasURLParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as canvas from '../libs/canvas';
 import * as feeds from '../libs/feeds';
@@ -7,6 +9,7 @@ import RoutesFunction from './routesFunction';
 export default ((app, db, socketIO) => {
 	app.post('/canvas/test', async (req, res) => {
 		try {
+			assertType<TestCanvasURLParameters>(req.body);
 			const { isValid, url } = await canvas.verifyURL(req.body.url);
 			api.success(res, { valid: isValid, url });
 		} catch (err) {
@@ -16,6 +19,7 @@ export default ((app, db, socketIO) => {
 
 	app.put('/canvas/url', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<SetCanvasURLParameters>(req.body);
 			const { isValid, validURL } = await canvas.setURL(db, req.apiUser!, req.body.url);
 			socketIO.user(req.apiUser!, 'canvas', 'set-url', validURL);
 			api.success(res, { valid: isValid, url: validURL });

--- a/src/routes/classAPI.ts
+++ b/src/routes/classAPI.ts
@@ -1,3 +1,5 @@
+import { AddClassParameters, DeleteClassParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as classes from '../libs/classes';
 import * as jwt from '../libs/jwt';
@@ -15,6 +17,13 @@ export default ((app, db, socketIO) => {
 	});
 
 	app.post('/classes', jwt.requireLoggedIn, async (req, res) => {
+		try {
+			assertType<AddClassParameters>(req.body);
+		} catch (err) {
+			api.error(res, err);
+			return;
+		}
+
 		const user = req.apiUser;
 		const scheduleClass = {
 			_id: req.body.id,
@@ -40,6 +49,7 @@ export default ((app, db, socketIO) => {
 
 	app.delete('/classes', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<DeleteClassParameters>(req.body);
 			await classes.delete(db, req.apiUser!, req.body.id);
 			socketIO.user(req.apiUser!, 'classes', 'delete', req.body.id);
 			api.success(res);

--- a/src/routes/modulesAPI.ts
+++ b/src/routes/modulesAPI.ts
@@ -1,3 +1,5 @@
+import { UpdateModulesParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as modules from '../libs/modules';
 import RoutesFunction from './routesFunction';
@@ -24,6 +26,7 @@ export default ((app, db) => {
 
 	app.put('/modules', async (req, res) => {
 		try {
+			assertType<UpdateModulesParameters>(req.body);
 			await modules.upsert(db, req.apiUser!, req.body.modules);
 		} catch (err) {
 			api.error(res, err);

--- a/src/routes/notificationsAPI.ts
+++ b/src/routes/notificationsAPI.ts
@@ -1,4 +1,4 @@
-import { UnsubscribeParameters } from '@mymicds/sdk';
+import { Scope } from '@mymicds/sdk';
 import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as notifications from '../libs/notifications';
@@ -7,17 +7,24 @@ import RoutesFunction from './routesFunction';
 export default ((app, db) => {
 
 	app.post('/notifications/unsubscribe', async (req, res) => {
+		// Union type is being difficult so we need to split this up
 		try {
-			assertType<UnsubscribeParameters>(req.body);
+			assertType<{ scopes: Scope | Scope[] }>(req.body);
 		} catch (err) {
 			api.error(res, err);
 			return;
 		}
 
 		let user = req.apiUser;
-		let hash = true;
+		let hash: string | true = true;
 
 		if (!user) {
+			try {
+				assertType<{ user: string, hash: string }>(req.body);
+			} catch (err) {
+				api.error(res, err);
+				return;
+			}
 			user = req.body.user;
 			hash = req.body.hash;
 		}

--- a/src/routes/notificationsAPI.ts
+++ b/src/routes/notificationsAPI.ts
@@ -1,3 +1,5 @@
+import { UnsubscribeParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as notifications from '../libs/notifications';
 import RoutesFunction from './routesFunction';
@@ -5,6 +7,13 @@ import RoutesFunction from './routesFunction';
 export default ((app, db) => {
 
 	app.post('/notifications/unsubscribe', async (req, res) => {
+		try {
+			assertType<UnsubscribeParameters>(req.body);
+		} catch (err) {
+			api.error(res, err);
+			return;
+		}
+
 		let user = req.apiUser;
 		let hash = true;
 

--- a/src/routes/plannerAPI.ts
+++ b/src/routes/plannerAPI.ts
@@ -1,3 +1,10 @@
+import {
+	AddPlannerEventParameters,
+	CheckPlannerEventParameters,
+	DeletePlannerEventParameters,
+	UncheckPlannerEventParameters
+} from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as checkedEvents from '../libs/checkedEvents';
 import * as planner from '../libs/planner';
@@ -15,6 +22,13 @@ export default ((app, db, socketIO) => {
 	});
 
 	app.post('/planner', async (req, res) => {
+		try {
+			type AddEventBody = Omit<AddPlannerEventParameters, 'start' | 'end'> & Partial<Record<'start' | 'end', string>>;
+			assertType<AddEventBody>(req.body);
+		} catch (err) {
+			api.error(res, err);
+			return;
+		}
 
 		let start = new Date();
 		if (req.body.start) {
@@ -26,7 +40,7 @@ export default ((app, db, socketIO) => {
 			end = new Date(req.body.end);
 		}
 
-		const insertEvent = {
+		const insertEvent: planner.NewEventData = {
 			_id    : req.body.id,
 			title  : req.body.title,
 			desc   : req.body.desc,
@@ -53,6 +67,7 @@ export default ((app, db, socketIO) => {
 
 	app.delete('/planner', async (req, res) => {
 		try {
+			assertType<DeletePlannerEventParameters>(req.body);
 			await planner.delete(db, req.apiUser!, req.body.id);
 			socketIO.user(req.apiUser!, 'planner', 'delete', req.body.id);
 			api.success(res);
@@ -63,6 +78,7 @@ export default ((app, db, socketIO) => {
 
 	app.patch('/planner/check', async (req, res) => {
 		try {
+			assertType<CheckPlannerEventParameters>(req.body);
 			await checkedEvents.check(db, req.apiUser!, req.body.id);
 			socketIO.user(req.apiUser!, 'planner', 'check', req.body.id);
 			api.success(res);
@@ -73,6 +89,7 @@ export default ((app, db, socketIO) => {
 
 	app.patch('/planner/uncheck', async (req, res) => {
 		try {
+			assertType<UncheckPlannerEventParameters>(req.body);
 			await checkedEvents.uncheck(db, req.apiUser!, req.body.id);
 			socketIO.user(req.apiUser!, 'planner', 'uncheck', req.body.id);
 			api.success(res);

--- a/src/routes/portalAPI.ts
+++ b/src/routes/portalAPI.ts
@@ -1,3 +1,5 @@
+import { SetPortalURLParameters, TestPortalURLParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as jwt from '../libs/jwt';
 import * as portal from '../libs/portal';
@@ -7,6 +9,7 @@ export default ((app, db, socketIO) => {
 
 	app.post('/portal/url/test-classes', async (req, res) => {
 		try {
+			assertType<TestPortalURLParameters>(req.body);
 			const { isValid, url } = await portal.verifyURLClasses(req.body.url);
 			api.success(res, { valid: isValid, url });
 		} catch (err) {
@@ -16,6 +19,7 @@ export default ((app, db, socketIO) => {
 
 	app.post('/portal/url/test-calendar', async (req, res) => {
 		try {
+			assertType<TestPortalURLParameters>(req.body);
 			const { isValid, url } = await portal.verifyURLCalendar(req.body.url);
 			api.success(res, { valid: isValid, url });
 		} catch (err) {
@@ -25,6 +29,7 @@ export default ((app, db, socketIO) => {
 
 	app.put('/portal/url/classes', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<SetPortalURLParameters>(req.body);
 			const { isValid, validURL } = await portal.setURLClasses(db, req.apiUser!, req.body.url);
 			socketIO.user(req.apiUser!, 'portal', 'set-url', validURL);
 			api.success(res, { valid: isValid, url: validURL });
@@ -35,6 +40,7 @@ export default ((app, db, socketIO) => {
 
 	app.put('/portal/url/calendar', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<SetPortalURLParameters>(req.body);
 			const { isValid, validURL } = await portal.setURLCalendar(db, req.apiUser!, req.body.url);
 			socketIO.user(req.apiUser!, 'portal', 'set-url', validURL);
 			api.success(res, { valid: isValid, url: validURL });

--- a/src/routes/quotesAPI.ts
+++ b/src/routes/quotesAPI.ts
@@ -1,3 +1,5 @@
+import { AddQuoteParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as quotes from '../libs/quotes';
 import RoutesFunction from './routesFunction';
@@ -19,6 +21,7 @@ export default ((app, db) => {
 
 	app.post('/quote', async (req, res) => {
 		try {
+			assertType<AddQuoteParameters>(req.body);
 			await quotes.insert(db, req.body.author, req.body.quote);
 			api.success(res);
 		} catch (err) {

--- a/src/routes/stickynotesAPI.ts
+++ b/src/routes/stickynotesAPI.ts
@@ -1,3 +1,5 @@
+import { AddStickyNoteParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as jwt from '../libs/jwt';
 import * as stickynotes from '../libs/stickynotes';
@@ -16,6 +18,7 @@ export default ((app, db) => {
 
 	app.put('/stickynotes', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<AddStickyNoteParameters>(req.body);
 			await stickynotes.post(db, req.apiUser!, req.body.moduleId, req.body.text);
 			api.success(res);
 		} catch (err) {

--- a/src/routes/stickynotesAPI.ts
+++ b/src/routes/stickynotesAPI.ts
@@ -1,4 +1,4 @@
-import { AddStickyNoteParameters } from '@mymicds/sdk';
+import { AddStickyNoteParameters, GetStickyNoteParameters } from '@mymicds/sdk';
 import { assertType } from 'typescript-is';
 import * as api from '../libs/api';
 import * as jwt from '../libs/jwt';
@@ -9,6 +9,7 @@ export default ((app, db) => {
 
 	app.get('/stickynotes', jwt.requireLoggedIn, async (req, res) => {
 		try {
+			assertType<GetStickyNoteParameters>(req.query);
 			const note = await stickynotes.get(db, req.apiUser!, req.query.moduleId);
 			api.success(res, note);
 		} catch (err) {

--- a/src/routes/suggestionAPI.ts
+++ b/src/routes/suggestionAPI.ts
@@ -1,3 +1,5 @@
+import { SubmitSuggestionParameters } from '@mymicds/sdk';
+import { assertType } from 'typescript-is';
 import * as admins from '../libs/admins';
 import * as api from '../libs/api';
 import RoutesFunction from './routesFunction';
@@ -5,6 +7,7 @@ import RoutesFunction from './routesFunction';
 export default ((app, db) => {
 	app.post('/suggestion', async (req, res) => {
 		try {
+			assertType<SubmitSuggestionParameters>(req.body);
 			await admins.sendEmail(db, {
 				subject: 'Suggestion From: ' + req.apiUser,
 				html: `Suggestion From: ${req.apiUser}\nType: ${req.body.type}\nSubmission: ${req.body.submission}`

--- a/src/routes/userAPI.ts
+++ b/src/routes/userAPI.ts
@@ -39,6 +39,9 @@ export default ((app, db, socketIO) => {
 	});
 
 	app.patch('/user/info', jwt.requireLoggedIn, async (req, res) => {
+		// All the validation is being done manually to add defaults
+		// No reason to add an assertType
+
 		const info: ChangeUserInfoParameters = {};
 
 		if (typeof req.body.firstName === 'string' && req.body.firstName !== '') {

--- a/src/scripts/newsletter.ts
+++ b/src/scripts/newsletter.ts
@@ -19,12 +19,12 @@ const DEBUG = true;
 // const debugList = ['mgira', 'nclifford', 'jcai'];
 const debugList = ['mgira'];
 
+import { Scope } from '@mymicds/sdk';
 import * as fs from 'fs-extra';
 import moment from 'moment';
 import { MongoClient } from 'mongodb';
 import * as nodemailer from 'nodemailer';
 import * as mail from '../libs/mail';
-import { Scope } from '../libs/notifications';
 import { UserDoc } from '../libs/users';
 
 if (!Object.values(Scope).includes(messageType)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-	"lib": ["esnext"],                             /* Specify library files to be included in the compilation. */
+	  "lib": ["esnext"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist",                       /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -38,10 +38,10 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    "typeRoots": ["node_modules/@types"],                       /* List of folders to include type definitions from. */
-    "types": ["node"],                           /* Type declaration files to be included in compilation. */
+    "typeRoots": ["node_modules/@types"],     /* List of folders to include type definitions from. */
+    "types": ["node"],                        /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true ,                 /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -53,5 +53,8 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "plugins": [
+      { "transform": "typescript-is/lib/transform-inline/transformer" }
+    ]
   }
 }


### PR DESCRIPTION
This PR introduces route-level input validation with [`typescript-is`](https://github.com/woutervh-/typescript-is) and [`ttypescript`](https://github.com/cevek/ttypescript), which allows for a safe removal of redundant `typeof` checks at the function level. Resolves #120.