### PR TITLE
Add Canvas cache creation timestamp

### DIFF
--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -376,7 +376,7 @@ export async function getUniqueEvents(db: Db) {
 	return assignments;
 }
 
-export type CanvasCacheEvent = ical.CalendarComponent & { _id: string | ObjectID, createdAt: Date };
+export type CanvasCacheEvent = ical.CalendarComponent & { _id: string | ObjectID, user: ObjectID, createdAt: Date };
 
 export interface UniqueEvent {
 	_id: string;

--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -376,7 +376,7 @@ export async function getUniqueEvents(db: Db) {
 	return assignments;
 }
 
-export type CanvasCacheEvent = ical.CalendarComponent & { _id: string | ObjectID };
+export type CanvasCacheEvent = ical.CalendarComponent & { _id: string | ObjectID, createdAt: Date };
 
 export interface UniqueEvent {
 	_id: string;

--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -28,8 +28,12 @@ export async function updateCanvasCache(db: Db, user: string) {
 
 	if (events === null || events.length === 0) { return; }
 
+	const creationDate = new Date();
+
 	for (const ev of events) {
 		(ev as any).user = userDoc!._id;
+		// Mongo operators don't work for insertMany so set creation time manually
+		(ev as any).createdAt = creationDate;
 	}
 
 	try {


### PR DESCRIPTION
In preparation for https://github.com/MyMICDS/MyMICDS-v2-Angular/issues/99, this PR adds a new `createdAt` field inside the Canvas cache to represent when the cache was last updated.