### PR TITLE
Add timestamp field to Canvas API response

### DIFF
--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -313,7 +313,8 @@ export async function getFromCache(db: Db, user: string) {
 			start,
 			end,
 			link: calendarToEvent(canvasEvent.url!) || '',
-			checked: checkedEventsList.includes(canvasEvent.uid!)
+			checked: checkedEventsList.includes(canvasEvent.uid!),
+			createdAt: canvasEvent.createdAt
 		};
 
 		if (typeof canvasEvent['ALT-DESC'] === 'object') {


### PR DESCRIPTION
In #145 I added a `createdAt` property to Canvas cache entries, but I forgot to actually add that property to the response. This PR does just that.