### PR TITLE
Skip MJML validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "main": "src/index.ts",
   "scripts": {
-    "build": "mjml -r src/email/* -o src/html/messages",
+    "build": "mjml -r src/email/* -o src/html/messages -c.validationLevel skip",
     "start": "npm run build && ts-node -C ttypescript --files src/index.ts",
     "prod": "npm run build && pm2 start ts-node -i max --name=\"mymicds\" -- -C ttypescript --files src/index.ts",
     "tasks": "pm2 start ts-node --name=\"mymicds-tasks\" -- -C ttypescript --files src/tasks.ts",


### PR DESCRIPTION
This PR turns off the MJML validator while still allowing it to compile so we don't get obnoxious errors for emails we know work. Fixes #147.