### PR TITLE
Add Sentry release hash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { initAPI } from './init';
 import * as Sentry from '@sentry/node';
 import config from './libs/config';
@@ -6,7 +7,9 @@ const port = process.env.PORT || config.port;
 
 Sentry.init({
 	dsn: 'https://7b1ca7e5c35043b3a79c69e83d4fd709@sentry.io/2721831',
-	enabled: config.production
+	enabled: config.production,
+	// NOTE: Will need to be changed if we ever stop using git for production deploys.
+	release: config.production ? execSync('git rev-parse HEAD').toString().trim() : 'DEV'
 });
 
 initAPI(config.mongodb.uri)


### PR DESCRIPTION
While working on https://github.com/MyMICDS/MyMICDS-v2-Angular/issues/114, I noticed that Sentry doesn't actually track releases inside issues unless it's initialized with the release tag. This PR takes advantage of the fact that we use git for production deploys to get the current release commit.