### PR TITLE
Fix for new Canvas URL formats

### DIFF
--- a/src/libs/canvas.ts
+++ b/src/libs/canvas.ts
@@ -161,7 +161,12 @@ function parseCanvasTitle(title: string) {
  * Turns a Canvas calendar link into an assignment link.
  * @param calLink Calendar link.
  */
-function calendarToEvent(calLink: string) {
+function calendarToEvent(calLink: string | WeirdCanvasUrl) {
+	// Normalize weird Canvas URL object into string with the value we care about
+	if (typeof calLink === 'object') {
+		calLink = calLink.val;
+	}
+
 	// Example calendar link:
 	// https://micds.instructure.com/calendar?include_contexts=course_XXXXXXX&month=XX&year=XXXX#assignment_XXXXXXX
 	// 'assignment' can also be 'calendar_event'
@@ -423,7 +428,13 @@ export type CanvasCacheEvent = ical.CalendarComponent & {
 	_id: string | ObjectID;
 	user: ObjectID;
 	createdAt: Date;
+	url?: string | WeirdCanvasUrl;
 };
+
+export interface WeirdCanvasUrl {
+	params: Record<string, string>; // Right now, only { "VALUE": "URI" }
+	val: string;
+}
 
 export interface UniqueEvent {
 	_id: string;


### PR DESCRIPTION
After grabbing a random user's URLs, I've gotten this error:
<img width="697" alt="image" src="https://github.com/MyMICDS/MyMICDS-v2/assets/6778537/c4b97156-e344-4a96-83a9-c33a0ae59796">

Which steps from the `url` field in the `canvasFeeds` collection to be formatted like so: `{"params": {"VALUE": "URI"}, "val": "https://micds.instructure.com/calendar?include_contexts=..."}`

This fix will first check if the URL is a string, and if not, use url.val