### PR TITLE
Remove periods from Canvas event description

### DIFF
--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -38,6 +38,10 @@ export async function updateCanvasCache(db: Db, user: string) {
 		ev.user = userDoc!._id;
 		// Mongo operators don't work for insertMany so set creation time manually
 		ev.createdAt = creationDate;
+
+		if (typeof ev.description === 'string') {
+			ev.description = ev.description.replace(/\./g, '&period;');
+		}
 	}
 
 	try {


### PR DESCRIPTION
Certain people will keep getting an error when visiting planner page: "Error! There was an error inserting events into the database!"

This occurs because in the Canvas description, there is a period. Replace with the HTML character